### PR TITLE
Add explicit null and Optional GraphQLValueType

### DIFF
--- a/Sources/GQLSchema/GraphQLValue.swift
+++ b/Sources/GQLSchema/GraphQLValue.swift
@@ -11,7 +11,7 @@ import Foundation
 public enum GraphQLValue<T: GraphQLValueType>: GraphQLValueType {
 
     /// Represents GraphQL literal `null` (explicitly sends `null` as the argument value).
-    /// Note: this is not Swift `nil` — use it when you need to override a default value or clear an optional field.
+    /// Note: this is not Swift `nil` — use this when you explicitly need to send a NULL value in order to override the current value of an optional field.
     case null
 
     /// can be specified only with value that has realisation of protocol *GraphQLValueType*

--- a/Sources/GQLSchema/GraphQLValue.swift
+++ b/Sources/GQLSchema/GraphQLValue.swift
@@ -10,6 +10,10 @@ import Foundation
 /// GraphQLValue function parameter for decelerating GraphQL query can contains value or variable
 public enum GraphQLValue<T: GraphQLValueType>: GraphQLValueType {
 
+    /// Represents GraphQL literal `null` (explicitly sends `null` as the argument value).
+    /// Note: this is not Swift `nil` — use it when you need to override a default value or clear an optional field.
+    case null
+
     /// can be specified only with value that has realisation of protocol *GraphQLValueType*
     case value(T)
 
@@ -18,6 +22,8 @@ public enum GraphQLValue<T: GraphQLValueType>: GraphQLValueType {
 
     public var _graphQLFormat: String {
         switch self {
+        case .null:
+            return "null"
         case .value(let value):
             return value._graphQLFormat
         case .variable(let name):

--- a/Sources/GQLSchema/GraphQLValueType.swift
+++ b/Sources/GQLSchema/GraphQLValueType.swift
@@ -65,3 +65,15 @@ extension Array: GraphQLValueType where Element: GraphQLValueType {
         return "[\(valueString)]"
     }
 }
+
+extension Optional: GraphQLValueType where Wrapped: GraphQLValueType {
+
+    public var _graphQLFormat: String {
+        switch self {
+        case .none:
+            "null"
+        case .some(let wrapped):
+            wrapped._graphQLFormat
+        }
+    }
+}


### PR DESCRIPTION
Introduce an explicit .null case to GraphQLValue to represent a literal GraphQL null (useful for overriding defaults or clearing optional fields) and update _graphQLFormat to emit "null". Add an Optional extension to conform Optional: GraphQLValueType when Wrapped: GraphQLValueType, serializing .none as "null" and .some by delegating to the wrapped value's formatting.